### PR TITLE
check for a power of 2 instead of a multiple of 2

### DIFF
--- a/lib/fast-fourier/fast-fourier.rb
+++ b/lib/fast-fourier/fast-fourier.rb
@@ -34,7 +34,7 @@ module FastFourier
 
   def FastFourier.discrete_fourier(vals, inverse = false)
     n = vals.length
-    if(n % 2 == 0)
+    if(n & (n-1) == 0)
       dft =  :cooley_tukey_dft
     else
       dft = :discrete_fourier_slow


### PR DESCRIPTION
To use the fast method it should check if it is a power of 2 and not just a multiple of 2. With a bitwise operator this is really easy and fast to do
